### PR TITLE
Rename stacked_tools with stacked_cli

### DIFF
--- a/docs/Tooling/stacked-cli.md
+++ b/docs/Tooling/stacked-cli.md
@@ -65,7 +65,7 @@ The way we know where to add modifications into your code is by reading what we 
 This command creates all the scaffolding to add a new view into the project. 
 
 1. Creates a new folder with the view name in `lib/ui/views/`
-2. Creates a new view and viewmodel files in `lib/ui/views/viewName/`
+2. Creates a new view and viewmodel files in `lib/ui/views/view_name/`
 3. Creates the ViewModel tests file in the `test/viewmodel_tests/` folder
 4. Adds the route to the `lib/app/app.dart` file
 
@@ -81,7 +81,7 @@ And underneath your last route add
 // @stacked-route
 ```
 
-Now if you run `stacked create view myView` you'll see that all the files are generated AND we also add the route into your `app.dart` file. The modifications are optional so if you don't have it they won't happen and everything else will still work. 
+Now if you run `stacked create view profile` you'll see that all the files are generated AND we also add the route into your `app.dart` file. The modifications are optional so if you don't have it they won't happen and everything else will still work. 
 
 ### Create Service
 
@@ -124,18 +124,18 @@ Underneath your last registration in `registerServices` add
 // @stacked-mock-register
 ```
 
-Now you can run `stacked create service myService` and you'll see the files created plus all the registration happens.
+Now you can run `stacked create service user` and you'll see the files created plus all the registration happens.
 
 ## Config
 
-If you want to use stacked_cli in a package that doesn't fit the structure that the cli expects then you can configure stacked to look in the correct places. Create a new file in the root of your package called `stacked.config.json`. Inside you can create a json body with the following properties:
+If you want to use stacked_cli in a package that doesn't fit the structure that the cli expects then you can configure stacked to look in the correct places. Create a new file in the root of your package called `stacked.json`. Inside you can create a json body with the following properties:
 
-- `views_path`: The relative path where views and viewmodels will be generated. The default value is: `lib/ui/views`
-- `services_path`: The relative path where services will be generated. The default value is: `lib/services`
-- `stacked_app_path`: The relative path to the file that contains the `StackedApp` setup. The default value is: `lib/app/app.dart`
-- `test_helpers_path`: The relative path to the file that contains the test_helpers (mocks, registerService, etc). Default: `test/helpers/test_helpers.dart`
-- `test_services_path`: The relative path to where the service's unit tests will be generated. Default: `test/services`
-- `test_views_path`: The relative path to where the viewmodel's unit tests will be generated. Default: `test/viewmodels`
+- `views_path`: The relative path where views and viewmodels will be generated. The default value is: `ui/views`
+- `services_path`: The relative path where services will be generated. The default value is: `services`
+- `stacked_app_path`: The relative path to the file that contains the `StackedApp` setup. The default value is: `app/app.dart`
+- `test_helpers_path`: The relative path to the file that contains the test_helpers (mocks, registerService, etc). Default: `helpers/test_helpers.dart`
+- `test_services_path`: The relative path to where the service's unit tests will be generated. Default: `services`
+- `test_views_path`: The relative path to where the viewmodel's unit tests will be generated. Default: `viewmodels`
 - `locator_name`: The name of the locator that mock services are registered on. This is used when creating a new service using the `create service` command. Default: `locator`
 - `register_mocks_function`: The name of the function that registers all the mocks when running a test. This is used when generating a test file during `create service` command. Default: `registerServices`
 

--- a/docs/Tooling/stacked-cli.md
+++ b/docs/Tooling/stacked-cli.md
@@ -1,19 +1,19 @@
 ---
-id: stacked-tools
-sidebar_label: "Stacked Tools"
+id: stacked-cli
+sidebar_label: "Stacked Cli"
 sidebar_position: 5
 ---
 
-# Stacked Tools[![Pub Version](https://img.shields.io/pub/v/stacked_tools)](https://pub.dev/packages/stacked_tools)
+# Stacked Cli [![Pub Version](https://img.shields.io/pub/v/stacked_cli)](https://pub.dev/packages/stacked_cli)
 
-The stacked cli is apart of the `stacked_tools` package. This CLI is made to speed up the development using the stacked framework.
+The Stacked cli is apart of the `stacked_cli` package. This CLI is made to speed up the development using the Stacked framework.
 
 ## Get Started
 
-To get started you have to install the `stacked_tools` package on your machine
+To get started you have to install the `stacked_cli` package on your machine
 
 ```shell
-dart pub global activate stacked_tools
+dart pub global activate stacked_cli
 ```
 
 ### Creating a Stacked app
@@ -128,7 +128,7 @@ Now you can run `stacked create service myService` and you'll see the files crea
 
 ## Config
 
-If you want to use stacked_tools in a package that doesn't fit the structure that the cli expects then you can configure stacked to look in the correct places. Create a new file in the root of your package called `stacked.config.json`. Inside you can create a json body with the following properties:
+If you want to use stacked_cli in a package that doesn't fit the structure that the cli expects then you can configure stacked to look in the correct places. Create a new file in the root of your package called `stacked.config.json`. Inside you can create a json body with the following properties:
 
 - `views_path`: The relative path where views and viewmodels will be generated. The default value is: `lib/ui/views`
 - `services_path`: The relative path where services will be generated. The default value is: `lib/services`

--- a/docs/basics-in-depth/services.md
+++ b/docs/basics-in-depth/services.md
@@ -53,7 +53,7 @@ class Artist {
 
 In the code above we can see that "the work being done" is all done by the `HomeViewModel`. This means the `HomeViewModel` has the responsibility to structure and make the http request (#1), check that it was successful (#2) and deserialise the response into a list of Artists (#3, #4, #5). This is quite common in Flutter, in fact, in most cases you are taught to do this in your `initState` function 🤯🤯, which if you're on this page. I beg you to never do.
 
-This is where the Facade Service comes in. The `HomeViewModel` like all other viewmodels is there to manage App State Logic and maintain the View state. It should not be doing the actual work mentioned above. To fix this, we introcude a service that wraps all this for us. This is what we want it to look like in our mental model.
+This is where the Facade Service comes in. The `HomeViewModel` like all other viewmodels is there to manage App State Logic and maintain the View state. It should not be doing the actual work mentioned above. To fix this, we introduce a service that wraps all this for us. This is what we want it to look like in our mental model.
 
 ![Stacked architecture breakdown that shows what code does the actual work](../../static/img/tutorial/services-who-does-the-work.png)
 
@@ -98,7 +98,7 @@ class HomeViewModel extends BaseViewModel {
 ```
 
 That's all that's required to create a Facade Service. With this small change, your code benefits in the following ways: 
-- **Seperation of Concerns / Single responsibiltiy**: You have now separated the concern of http requests, desrialise, error checking and model construction from the viewmodel. The ViewModel can now focus only on managing the state for the view.
+- **Separation of Concerns / Single responsibility**: You have now separated the concern of http requests, deserialise, error checking and model construction from the viewmodel. The ViewModel can now focus only on managing the state for the view.
 - **More Testable**: Since the hard dependency on the Http package has been removed it means you can mock out the `apiService` and write deterministic unit tests for your viewmodel. 
 - **DRY Code**: Any other Viewmodel, or service that requires this functionality can simply locate the service and make use of the `getArtists` function. No need to repeat it somewhere else.
 - **Code Readability**: This is my opinion, but the code looks better and it's easy to see at a high level what's expected of the code without having to see the construction of http requests and the messyness of deserialising that into a separate list. 
@@ -107,7 +107,7 @@ This pattern is the core of Stacked's appeal. In almost every situation the Stac
 
 ### App Service
 
-An App Service (for lack of a better name) is where your business logic lies. These types of services orchastrate the interaction between Facade services to complete some domain (business) logic. Take for example an `ArtistService` that has a function that does the following: 
+An App Service (for lack of a better name) is where your business logic lies. These types of services orchestrate the interaction between Facade services to complete some domain (business) logic. Take for example an `ArtistService` that has a function that does the following: 
 
 - Check if a user is logged in
 - Fetch artists when a user is logged in

--- a/docs/getting-started/00-overview.md
+++ b/docs/getting-started/00-overview.md
@@ -21,10 +21,10 @@ Now with its own CLI, it makes it even easier to get into Stacked.
 Make sure you have Flutter installed and setup. If not head over to [Flutter Install](https://docs.flutter.dev/get-started/install) to get is setup
 :::
 
-To start with stacked install the stacked_tools package through pub by running 
+To start with stacked install the stacked_cli package through pub by running 
 
 ```shell
-dart pub global activate stacked_tools
+dart pub global activate stacked_cli
 ```
 
 This will give you access to all the stacked goodies. 


### PR DESCRIPTION
- Renamed `stacked_tools` with `stacked_cli`
- Fixed typos
- Fixed Stacked config default values
- Changed view name and service name to avoid confusion