### PR TITLE
Document review and corrections for Tooling

### DIFF
--- a/docs/tooling/stacked-cli.md
+++ b/docs/tooling/stacked-cli.md
@@ -1,149 +1,151 @@
 ---
 id: stacked-cli
-sidebar_label: "Stacked Cli"
+sidebar_label: "Stacked CLI"
 sidebar_position: 5
 ---
 
-# Stacked Cli [![Pub Version](https://img.shields.io/pub/v/stacked_cli)](https://pub.dev/packages/stacked_cli)
 
-The Stacked cli is apart of the `stacked_cli` package. This CLI is made to speed up the development using the Stacked framework.
+# Stacked CLI [![Pub Version](https://img.shields.io/pub/v/stacked_cli)](https://pub.dev/packages/stacked_cli)
 
-## Get Started
+The Stacked CLI is a part of the `stacked_cli` package. The CLI was created to speed up development using the Stacked framework.
 
-To get started you have to install the `stacked_cli` package on your machine
+
+## Getting Started
+
+To get started, install the `stacked_cli` package on your machine:
 
 ```shell
 dart pub global activate stacked_cli
 ```
 
-### Creating a Stacked app
+### Creating a Stacked App
 
-To create your first stacked app all you need to do is run
+To create your first Stacked app, all you need to do is run:
 
 ```shell
 stacked create app my_app
 ```
 
-This will create a new flutter app based on your flutter version, add all the code required for a stacked app and generate the required code. When the command completes navigate into the my_app folder and run it. 
+This will create a new flutter app based on your flutter version, add all the code required for a Stacked app and generate the required code. When the command completes navigate into the my_app folder and run the app.
 
-### Add a new view
+### Add a New View
 
-At the root of your stacked application and type the command 
+From the root folder of your Stacked application, run the command:
 
 ```shell
 stacked create view login
 ```
 
-This will create a new view called `LoginView` with its viewmodel in the `ui/views` folder. This will also create the viewmodel tests file as well as add the view to the routes in app.dart file. 
+This will create a new View called `LoginView` with its associated ViewModel in the `ui/views` folder. This will also create the ViewModel tests file, as well as add the View to the available routes in `app.dart` file.
 
-### Add a new service
+### Add a New Service
 
-At the root of your stacked application type the command
+From the root folder of your Stacked application, run the command:
 
 ```shell
 stacked create service stripe
 ```
 
-This will create a new service called `StripeService` in the services folder and add it to the dependencies in the `app.core` file. 
+This will create a new Service called `StripeService` in the `services` folder and add it to the dependencies in the `app.dart` file.
 
 ### Generate Stacked Code
 
-When you've changed something manually, or added a new model. Instead of executing the command `flutter pub run build_runner build --delete-conflicting-outputs` you can simply run `stacked generate`.
+When you've changed something manually, or added a new model, instead of executing the command `flutter pub run build_runner build --delete-conflicting-outputs` you can simply run `stacked generate`.
 
 ### Update CLI
 
-When you want to update `stacked_cli` app. Instead of executing the command `dart pub global activate stacked_cli` you can simply run `stacked update`.
+When you want to update a `stacked_cli` app, instead of executing the command `dart pub global activate stacked_cli` you can simply run `stacked update`.
 
-## Use cli on existing project
 
-Using the stacked cli in an existing project takes a little bit more effort than above. There's a few things you have to ensure.
+## Use the CLI with Existing Project
+
+Using the Stacked CLI with an existing project takes a little bit more effort than above. There are a few things that you have to ensure:
 
 1. You need to have your app file in `lib/app/app.dart`
 2. If you have tests setup as presented in the [unit testing videos](https://youtu.be/5BFlo9k3KNU) your helper file should be `test/helpers/test_helpers.dart`
-3. You tell stacked where to make modifications
+3. You tell Stacked where to make the modifications
 
-The way we know where to add modifications into your code is by reading what we call a **template identifier**. This tells our tools, "At this position you can make a modification". At the moment we only have 2 scaffolding commands:
+The way we know where to add modifications into your code is by reading what we call a **template identifier**. This tells our tools, "At this position you can make a modification". For now, we only have two scaffolding commands:
 
 ### Create View
 
-This command creates all the scaffolding to add a new view into the project. 
+This command creates all the scaffolding to add a new View into the project:
 
-1. Creates a new folder with the view name in `lib/ui/views/`
-2. Creates a new view and viewmodel files in `lib/ui/views/view_name/`
+1. Creates a new folder with the View name in `lib/ui/views/`
+2. Creates the new View and ViewModel files in `lib/ui/views/view_name/`
 3. Creates the ViewModel tests file in the `test/viewmodel_tests/` folder
 4. Adds the route to the `lib/app/app.dart` file
 
-For us to achieve #4 we need to know where to add the route and its import. To indicate that we use the **template identifiers**. Open your `lib/app/app.dart` file and underneath the last import add
+For us to achieve #4, we need to know where to add the route and its import. To indicate that we use the **template identifiers**, open your `lib/app/app.dart` file and under the last import, add:
 
 ```dart
 // @stacked-import
 ```
 
-And underneath your last route add
+And underneath your last route add:
 
 ```dart
 // @stacked-route
 ```
 
-Now if you run `stacked create view profile` you'll see that all the files are generated AND we also add the route into your `app.dart` file. The modifications are optional so if you don't have it they won't happen and everything else will still work. 
+Now if you run `stacked create view profile` you'll see that all the files are generated AND we also add the route into your `app.dart` file. The modifications are optional so if you don't have the template identifiers, Stacked will still generate the necessary files but won't automatically add the route to your `app.dart` file. Everything else will still work though.
 
 ### Create Service
 
-This command creates all the scaffolding to add a new service into the project.
+This command creates all the scaffolding to add a new Service into the project:
 
-1. Creates a new service file in `lib/services/`
+1. Creates a new Service file in `lib/services/`
 2. Creates the unit tests file in `test/services/`
-3. Registers the service with your `StackedApp`
-4. Adds the service Mock into the test_helpers and registers it
+3. Registers the Service with your `StackedApp`
+4. Adds the Service Mock into the test_helpers and registers it
 
-To allow for #3 we need to add the identifier to our file that contains our dependency registrations. Open up your file that contains your `StackedApp` and add 
+For us to achieve #3, we need to know where to add the dependency registration. Open your `lib/app/app.dart` file and under the last dependency registration, add:
 
 ```dart
 // @stacked-service
 ```
 
-Under the last dependency registration.
-
-To allow for #4 we need to know where to add the service Mock, it's registration and its import. Open up your test_helper.dart file and under all the imports add 
+For us to achieve #4, we need to know where to add the Service Mock. Open your `test_helpers.dart` file and under all the imports, add:
 
 ```dart
 // @stacked-import
 ```
 
-Underneath your last `MockSpec<T>()` add
+Under your last `MockSpec<T>()`, add:
 
 ```dart
 // @stacked-mock-spec
 ```
 
-Underneath your last `getAndRegisterService` that creates a mock and returns add
+Under your last `getAndRegisterService` that creates a Mock and returns it, add:
 
 ```dart
 // @stacked-mock-create
 ```
 
-Underneath your last registration in `registerServices` add 
+Under your last Service registration in `registerServices`, add:
 
 ```dart
 // @stacked-mock-register
 ```
 
-Now you can run `stacked create service user` and you'll see the files created plus all the registration happens.
+Now, when you run `stacked create service user`, you'll see the files created for the `UserService` and all the registration will happen automatically.
+
 
 ## Config
 
-If you want to use stacked_cli in a package that doesn't fit the structure that the cli expects then you can configure stacked to look in the correct places. Create a new file in the root of your package called `stacked.json`. Inside you can create a json body with the following properties:
+If you want to use `stacked_cli` in a package that doesn't fit the structure that the CLI expects, then you can configure Stacked to look in the correct places. Create a new file in the root folder of your package called `stacked.json`. Inside the file, create a JSON body with the following properties:
 
-- `views_path`: The relative path where views and viewmodels will be generated. The default value is: `ui/views`
-- `services_path`: The relative path where services will be generated. The default value is: `services`
+- `views_path`: The relative path where Views and ViewModels will be generated. The default value is: `ui/views`
+- `services_path`: The relative path where Services will be generated. The default value is: `services`
 - `stacked_app_path`: The relative path to the file that contains the `StackedApp` setup. The default value is: `app/app.dart`
 - `test_helpers_path`: The relative path to the file that contains the test_helpers (mocks, registerService, etc). Default: `helpers/test_helpers.dart`
-- `test_services_path`: The relative path to where the service's unit tests will be generated. Default: `services`
-- `test_views_path`: The relative path to where the viewmodel's unit tests will be generated. Default: `viewmodels`
-- `locator_name`: The name of the locator that mock services are registered on. This is used when creating a new service using the `create service` command. Default: `locator`
-- `register_mocks_function`: The name of the function that registers all the mocks when running a test. This is used when generating a test file during `create service` command. Default: `registerServices`
+- `test_services_path`: The relative path to where the Services' unit tests will be generated. Default: `services`
+- `test_views_path`: The relative path to where the ViewModels' unit tests will be generated. Default: `viewmodels`
+- `locator_name`: The name of the locator that Services are registered with. This is used when creating a new Service using the `create service` command. Default: `locator`
+- `register_mocks_function`: The name of the function that registers all the Mocks when running a test. This is used when generating a test file during `create service` command. Default: `registerServices`
 
-Only included the paths you want to use. If you exclude one the default value will be used for it. 
+Only include the paths you want to customize. If you exclude a path, the default value will be used for it.
 
 ### Example
 
@@ -157,7 +159,7 @@ Only included the paths you want to use. If you exclude one the default value wi
     "test_views_path" : "viewmodels",
     "locator_name" : "locator",
     "register_mocks_function" : "registerServices",
-    "v1": false, // Indicates if you want to use ViewModelBuilder(v1) or the the new StackedView (v2)
-    "line_length": 80 // Passed into the flutter formatter when running cli commands
+    "v1": false, // Indicates whether you want to use ViewModelBuilder(v1) or the the new StackedView (v2)
+    "line_length": 80 // Passed into the flutter formatter when running CLI commands
 }
 ```


### PR DESCRIPTION
Complete review of the Tooling section making the following changes:

Consistent titles and sidebar_labels
Consistent headers and header spacing
Remove trailing spaces
Consistent package naming
Consistent punctuation
Correct typos
Americanize spelling to cater for a wider audience