### PR TITLE
Enable locale dropdown on NavBar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,10 +91,10 @@ const config = {
           src: 'img/logo.png',
         },
         items: [
-          // {
-          //   type: 'localeDropdown',
-          //   position: 'right',
-          // },
+          {
+            type: 'localeDropdown',
+            position: 'right',
+          },
           {
             href: 'https://github.com/Filledstacks/stacked',
             position: 'right',


### PR DESCRIPTION
As we have the documentation fully translated into Spanish we can show the locale dropdown on the NavBar.

Merge after #46, #47, #48